### PR TITLE
Refactor achievements UI and add new rewards

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,17 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div class="achievements-panel">
+    <button id="achievementsBtn" class="achievements-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="achievementsDropdown">
+      <span class="icon">🏆</span>
+      <span class="label">Достижения</span>
+      <span class="chevron">▾</span>
+    </button>
+    <div id="achievementsDropdown" class="ach-dropdown hidden" role="menu" aria-hidden="true">
+      <ul id="achievementsList" class="ach-list"></ul>
+    </div>
+  </div>
+
   <div class="game-container">
     <h1>🦊 Ясак Кликер</h1>
 
@@ -18,9 +29,6 @@
 
     <div class="top-controls">
       <button id="clickButton"><span class="icon">🎯</span><span class="label">Добыть пушнину</span></button>
-      <button id="achievementsBtn" class="has-tip" data-tip="Открыть список достижений">
-        <span class="icon">🏆</span><span class="label">Достижения</span>
-      </button>
     </div>
 
     <div class="upgrades">
@@ -73,18 +81,6 @@
           <span class="label">Сброс прогресса</span>
         </button>
       </div>
-    </div>
-  </div>
-
-  <!-- МОДАЛЬНОЕ ОКНО ДОСТИЖЕНИЙ -->
-  <div id="achievementsModal" class="modal hidden" aria-hidden="true">
-    <div class="modal-backdrop" data-close></div>
-    <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="achTitle">
-      <div class="modal-header">
-        <h3 id="achTitle">🏆 Достижения</h3>
-        <button class="modal-close" id="achClose" title="Закрыть" data-close>✖</button>
-      </div>
-      <div id="achievementsList" class="ach-grid"></div>
     </div>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -17,11 +17,16 @@ const COSTS = { traps: 50, hunters: 20, zimovye: 200, dogs: 300 };
 
 // ===== ДОСТИЖЕНИЯ =====
 const ACHIEVEMENTS = [
-  { id: 'first_fur',  name: 'Первая шкурка',     desc: 'Получите первую шкурку',            img: 'achievement_placeholder.png', test: (s)=> s.fursTotal >= 1 },
-  { id: '100_furs',   name: 'Сотня пушнины',     desc: 'Добыть 100 пушнины',                img: 'achievement_placeholder.png', test: (s)=> s.fursTotal >= 100 },
-  { id: '1000_furs',  name: 'Тысяча пушнины',    desc: 'Добыть 1000 пушнины',               img: 'achievement_placeholder.png', test: (s)=> s.fursTotal >= 1000 },
-  { id: '10_traps',   name: 'Мастер ловушек',    desc: 'Поставить 10 ловушек',              img: 'achievement_placeholder.png', test: (s)=> s.traps >= 10 },
-  { id: '20_hunters', name: 'Сила артели',       desc: 'Собрать 20 охотников',              img: 'achievement_placeholder.png', test: (s)=> s.hunters >= 20 },
+  { id: 'first_fur',     name: 'Первая шкурка',       desc: 'Получите первую шкурку',               img: 'https://cdn-icons-png.flaticon.com/512/616/616490.png', test: (s)=> s.fursTotal >= 1 },
+  { id: 'first_hunter',  name: 'Первый артельщик',    desc: 'Принять первого охотника',             img: 'https://cdn-icons-png.flaticon.com/512/599/599502.png', test: (s)=> s.hunters >= 1 },
+  { id: 'first_zimovye', name: 'Первое зимовье',      desc: 'Построить ясачное зимовье',            img: 'https://cdn-icons-png.flaticon.com/512/3076/3076129.png', test: (s)=> s.zimovye >= 1 },
+  { id: '100_furs',      name: 'Сотня пушнины',       desc: 'Добыть 100 пушнины',                   img: 'https://cdn-icons-png.flaticon.com/512/805/805370.png', test: (s)=> s.fursTotal >= 100 },
+  { id: '10_traps',      name: 'Мастер ловушек',      desc: 'Поставить 10 ловушек',                 img: 'https://cdn-icons-png.flaticon.com/512/3595/3595455.png', test: (s)=> s.traps >= 10 },
+  { id: '20_hunters',    name: 'Сила артели',         desc: 'Собрать 20 охотников',                 img: 'https://cdn-icons-png.flaticon.com/512/3417/3417886.png', test: (s)=> s.hunters >= 20 },
+  { id: '25_traps',      name: 'Хозяин угодий',       desc: 'Поставить 25 ловушек',                 img: 'https://cdn-icons-png.flaticon.com/512/2921/2921822.png', test: (s)=> s.traps >= 25 },
+  { id: '1000_furs',     name: 'Тысяча пушнины',      desc: 'Добыть 1000 пушнины',                  img: 'https://cdn-icons-png.flaticon.com/512/2682/2682065.png', test: (s)=> s.fursTotal >= 1000 },
+  { id: 'pack_of_hounds',name: 'Верная стая',         desc: 'Собрать 10 охотничьих псов',           img: 'https://cdn-icons-png.flaticon.com/512/616/616408.png', test: (s)=> s.dogs >= 10 },
+  { id: '5000_furs',     name: 'Богатства тайги',     desc: 'Добыть 5000 пушнины',                  img: 'https://cdn-icons-png.flaticon.com/512/1046/1046751.png', test: (s)=> s.fursTotal >= 5000 },
 ];
 
 function hasAch(id){ return STATE.achievements.includes(id); }
@@ -56,9 +61,8 @@ const elements = {
   dogsUpgrade: $("dogs"),
   resetButton: $("reset"),
   achievementsBtn: $("achievementsBtn"),
-  achievementsModal: $("achievementsModal"),
+  achievementsDropdown: $("achievementsDropdown"),
   achievementsList: $("achievementsList"),
-  achClose: $("achClose"),
   toastHost: $("achievementToastHost"),
 };
 
@@ -123,26 +127,29 @@ function renderAchievements(){
   const opened = [], locked = [];
   for (const a of ACHIEVEMENTS){ (hasAch(a.id) ? opened : locked).push(a); }
   const list = [...opened, ...locked];
-  elements.achievementsList.innerHTML = list.map(a => `
-    <div class=\"ach-card ${hasAch(a.id) ? 'open' : 'locked'}\">
-      <img src=\"${a.img}\" alt=\"${a.name}\" class=\"ach-img\" />
-      <div class=\"ach-body\">
-        <div class=\"ach-title\">${a.name}</div>
-        <div class=\"ach-desc\">${a.desc}</div>
-      </div>
-    </div>
-  `).join('');
+  elements.achievementsList.innerHTML = list.map(a => {
+    const unlocked = hasAch(a.id);
+    return `
+      <li class=\"ach-card ${unlocked ? 'open' : 'locked'}\" role=\"menuitem\">
+        <img src=\"${a.img}\" alt=\"${a.name}\" class=\"ach-img\" />
+        <div class=\"ach-body\">
+          <div class=\"ach-title\">${a.name}</div>
+          <div class=\"ach-desc\">${a.desc}</div>
+        </div>
+      </li>
+    `;
+  }).join('');
 }
 
-function openAchievements(){
-  renderAchievements();
-  elements.achievementsModal.classList.remove('hidden');
-  elements.achievementsModal.setAttribute('aria-hidden','false');
+let _achievementsOpen = false;
+function setAchievementsOpen(isOpen){
+  _achievementsOpen = isOpen;
+  elements.achievementsDropdown.classList.toggle('hidden', !isOpen);
+  elements.achievementsDropdown.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+  elements.achievementsBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  if (isOpen) renderAchievements();
 }
-function closeAchievements(){
-  elements.achievementsModal.classList.add('hidden');
-  elements.achievementsModal.setAttribute('aria-hidden','true');
-}
+function toggleAchievements(){ setAchievementsOpen(!_achievementsOpen); }
 
 // ===== ТОСТ О ДОСТИЖЕНИИ =====
 function showAchievementToast(ach){
@@ -155,7 +162,7 @@ function showAchievementToast(ach){
   `;
   card.addEventListener('click', ()=> card.remove());
   elements.toastHost.appendChild(card);
-  setTimeout(()=> card.remove(), 6000);
+  setTimeout(()=> card.remove(), 10000);
 }
 
 let _rafScheduled = false;
@@ -281,16 +288,24 @@ function incomeTick(nowMs){
 
 // ===== ИНИЦИАЛИЗАЦИЯ =====
 function init(){
-  loadGame(); recalcRates();
+  loadGame(); recalcRates(); checkAchievements();
   elements.clickButton.addEventListener("click", handleClick);
   elements.huntersUpgrade.addEventListener("click", handleHunterUpgrade);
   elements.trapsUpgrade.addEventListener("click", handleTrapUpgrade);
   elements.zimovyeUpgrade.addEventListener("click", handleZimovyeUpgrade);
   elements.dogsUpgrade.addEventListener("click", handleDogsUpgrade);
   elements.resetButton.addEventListener("click", resetProgress);
-  elements.achievementsBtn.addEventListener('click', openAchievements);
-  elements.achievementsModal.addEventListener('click', (e)=>{ if (e.target.hasAttribute('data-close')) closeAchievements(); });
-  elements.achClose.addEventListener('click', closeAchievements);
+  elements.achievementsBtn.addEventListener('click', (ev)=>{ ev.stopPropagation(); toggleAchievements(); });
+  elements.achievementsDropdown.addEventListener('click', (ev)=> ev.stopPropagation());
+  document.addEventListener('click', (ev)=>{
+    if (!_achievementsOpen) return;
+    if (!elements.achievementsBtn.contains(ev.target) && !elements.achievementsDropdown.contains(ev.target)) {
+      setAchievementsOpen(false);
+    }
+  });
+  document.addEventListener('keydown', (ev)=>{ if (ev.key === 'Escape' && _achievementsOpen) setAchievementsOpen(false); });
+  renderAchievements();
+  setAchievementsOpen(false);
   renderNow(); requestAnimationFrame(incomeTick);
 }
 if (document.readyState==='complete' || document.readyState==='interactive') init(); else window.addEventListener('DOMContentLoaded', init);

--- a/style.css
+++ b/style.css
@@ -20,6 +20,58 @@ body {
   color: #3d2b1f;
 }
 
+.hidden { display: none !important; }
+
+.achievements-panel {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  z-index: 400;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.achievements-btn {
+  width: 240px;
+  height: auto;
+  margin: 0;
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 15px;
+}
+
+.achievements-btn .icon { font-size: 18px; }
+.achievements-btn .label { flex: 1; text-align: left; }
+.achievements-btn .chevron { font-size: 14px; opacity: 0.8; }
+
+.ach-dropdown {
+  width: 280px;
+  background: rgba(255, 248, 220, 0.98);
+  border: 2px solid #8b4513;
+  border-radius: 14px;
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.35);
+  padding: 10px;
+  max-height: 340px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ach-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 .game-container {
   background: rgba(255, 248, 220, 0.9);
   padding: 25px;
@@ -109,27 +161,53 @@ h1 { color: #5d1917; text-shadow: 1px 1px 2px #ccc; }
 }
 .has-tip:hover::after { opacity: 1; transform: translateX(-50%) translateY(-12px); }
 
-/* ==== Модалка достижений ==== */
-.modal.hidden { display:none; }
-.modal { position: fixed; inset: 0; z-index: 200; }
-.modal-backdrop { position:absolute; inset:0; background: rgba(0,0,0,.4); }
-.modal-content { position: relative; margin: 6vh auto; width: min(920px, 92vw); background: #fff8dc; border: 2px solid #8b4513; border-radius: 14px; box-shadow: 0 20px 60px rgba(0,0,0,.35); padding: 14px; }
-.modal-header { display:flex; align-items:center; justify-content:space-between; margin-bottom: 8px; }
-.modal-close { width:auto; height:auto; background:#8b4513; color:#fff8dc; padding:6px 10px; border-radius:8px; }
+/* ==== Выпадающий список достижений ==== */
+.ach-card {
+  display: flex;
+  gap: 10px;
+  background: #fff;
+  border: 1px solid #d7c5a3;
+  border-radius: 10px;
+  padding: 8px 10px;
+  align-items: center;
+  box-shadow: 0 2px 10px rgba(0,0,0,.08);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
 
-.ach-grid { display:grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 12px; padding: 10px; }
-.ach-card { display:flex; gap:10px; background:#fff; border:1px solid #d7c5a3; border-radius: 10px; padding: 10px; align-items:center; box-shadow: 0 2px 8px rgba(0,0,0,.06); }
-.ach-card.locked { filter: grayscale(1); opacity: .65; }
-.ach-img { width: 64px; height: 64px; object-fit: cover; border-radius: 8px; border:1px solid #c9b18a; }
+.ach-card.open {
+  background: #fff4d8;
+  border-color: #c89b51;
+}
+
+.ach-card:hover {
+  transform: translateX(4px);
+  box-shadow: 0 4px 16px rgba(0,0,0,.12);
+}
+
+.ach-card.locked {
+  filter: grayscale(1);
+  opacity: 0.65;
+}
+
+.ach-img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid #c9b18a;
+  flex-shrink: 0;
+}
+
 .ach-body { text-align:left; }
-.ach-title { font-weight: 700; margin-bottom: 4px; }
-.ach-desc { font-size: 14px; opacity: .85; }
+.ach-title { font-weight: 700; margin-bottom: 2px; }
+.ach-desc { font-size: 13px; opacity: .85; line-height: 1.35; }
 
 /* ==== Тост об открытии достижения ==== */
 .toast-host { position: fixed; inset: auto 0 24px 0; display:flex; justify-content:center; pointer-events:none; z-index: 250; }
 .toast-card { position: relative; background:#fffef5; border:2px solid #e0c781; border-radius: 14px; padding: 10px 14px; display:flex; gap:10px; align-items:center; box-shadow: 0 12px 28px rgba(0,0,0,.25); animation: toast-in .25s ease-out both; pointer-events:auto; cursor:pointer; }
 .toast-card img { width:48px; height:48px; border-radius:8px; border:1px solid #d7c5a3; }
 .toast-text { color:#5a3c18; }
+.toast-text strong { color:#c63b3b; }
 .toast-glow { position:absolute; inset:-6px; border-radius:18px; box-shadow: 0 0 24px 6px rgba(255, 215, 0, .6), 0 0 48px 12px rgba(255, 160, 0, .4); pointer-events:none; animation: glow 1.2s ease-in-out infinite alternate; }
 @keyframes glow { from { opacity:.85; } to { opacity:.45; } }
 @keyframes toast-in { from { transform: translateY(16px); opacity:0; } to { transform: translateY(0); opacity:1; } }


### PR DESCRIPTION
## Summary
- move the achievements entry point into a fixed dropdown panel in the top-left corner and remove the old modal
- restyle the dropdown list to be vertical, adjust toast styling, and keep notifications visible for 10 seconds
- expand the achievements roster with new goals using flaticon icons and update the game bootstrap to refresh progress accordingly

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d13983fe448331a4407b57b0d6c20f