### PR TITLE
Animate strelets sprite in both directions

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,11 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="background-character" aria-hidden="true"></div>
+  <div class="background-character" aria-hidden="true">
+    <div class="background-character__sprite">
+      <div class="background-character__image"></div>
+    </div>
+  </div>
   <div class="achievements-panel">
     <button id="achievementsBtn" class="achievements-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="achievementsDropdown">
       <span class="icon">🏆</span>

--- a/style.css
+++ b/style.css
@@ -141,7 +141,7 @@ h1 { color: #5d1917; text-shadow: 1px 1px 2px #ccc; }
   position: fixed;
   font-size: 30px;
   pointer-events: none;
-  z-index: 100;
+  z-index: 450;
   transition: all 0.6s ease-out;
   opacity: 0;
 }
@@ -229,45 +229,113 @@ h1 { color: #5d1917; text-shadow: 1px 1px 2px #ccc; }
   left: -22vw;
   width: min(24vw, 280px);
   height: min(36vw, 360px);
-  background-image: url('strelets.png');
+  pointer-events: none;
+  z-index: 60;
+  perspective: 1200px;
+  transform-origin: center bottom;
+  animation: strelets-wander 32s linear infinite;
+  will-change: transform;
+}
+
+.background-character__sprite {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  transform-origin: center bottom;
+  transform-style: preserve-3d;
+  animation: strelets-turn 32s ease-in-out infinite;
+}
+
+.background-character__image {
+  width: 100%;
+  height: 100%;
+  background-image: url('strelets_sprite_clean.svg');
   background-repeat: no-repeat;
   background-size: contain;
   background-position: center bottom;
-  z-index: 60;
-  pointer-events: none;
-  opacity: 0;
-  animation: strelets-wander 26s linear infinite;
-  will-change: transform, opacity;
+  animation: strelets-bob 2.4s ease-in-out infinite;
+  will-change: transform;
 }
 
 @keyframes strelets-wander {
   0% {
     transform: translate3d(0, -18px, 0) scale(0.86);
-    opacity: 0;
   }
-  5% {
-    transform: translate3d(8vw, 8px, 0) scale(0.9);
-    opacity: 1;
+  8% {
+    transform: translate3d(8vw, 6px, 0) scale(0.9);
   }
-  20% {
+  22% {
     transform: translate3d(28vw, -10px, 0) scale(0.98);
   }
   40% {
     transform: translate3d(50vw, 14px, 0) scale(1.06);
   }
-  60% {
+  52% {
     transform: translate3d(72vw, -8px, 0) scale(1.14);
   }
-  80% {
-    transform: translate3d(96vw, 18px, 0) scale(1.22);
-    opacity: 1;
+  60% {
+    transform: translate3d(94vw, 18px, 0) scale(1.21);
   }
-  90% {
-    transform: translate3d(114vw, -14px, 0) scale(1.26);
-    opacity: 0.6;
+  64% {
+    transform: translate3d(102vw, 12px, 0) scale(1.24);
+  }
+  68% {
+    transform: translate3d(94vw, 16px, 0) scale(1.21);
+  }
+  78% {
+    transform: translate3d(70vw, -6px, 0) scale(1.12);
+  }
+  88% {
+    transform: translate3d(46vw, 12px, 0) scale(1.02);
+  }
+  96% {
+    transform: translate3d(18vw, -12px, 0) scale(0.92);
   }
   100% {
-    transform: translate3d(130vw, 0, 0) scale(1.18);
-    opacity: 0;
+    transform: translate3d(0, -18px, 0) scale(0.86);
+  }
+}
+
+@keyframes strelets-turn {
+  0%, 44% {
+    transform: rotateY(0deg);
+  }
+  48% {
+    transform: rotateY(35deg);
+  }
+  52% {
+    transform: rotateY(90deg);
+  }
+  56% {
+    transform: rotateY(180deg);
+  }
+  86% {
+    transform: rotateY(180deg);
+  }
+  90% {
+    transform: rotateY(215deg);
+  }
+  96% {
+    transform: rotateY(300deg);
+  }
+  100% {
+    transform: rotateY(360deg);
+  }
+}
+
+@keyframes strelets-bob {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  25% {
+    transform: translateY(-3%);
+  }
+  50% {
+    transform: translateY(-1%);
+  }
+  75% {
+    transform: translateY(-4%);
   }
 }


### PR DESCRIPTION
## Summary
- swap the background wanderer to the cleaned SVG sprite and restructure the markup for nested animation layers
- create bidirectional walk, turn, and bob animations so the character crosses the screen smoothly without fading
- raise the fox gain popup above the UI so its emoji and numbers stay visible

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d1701a721c83319bc09a9ac23af137