### PR TITLE
Restore PNG sprite and edge turns

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,11 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="background-character" aria-hidden="true"></div>
+  <div class="background-character" aria-hidden="true">
+    <div class="background-character__sprite">
+      <div class="background-character__image"></div>
+    </div>
+  </div>
   <div class="achievements-panel">
     <button id="achievementsBtn" class="achievements-btn" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="achievementsDropdown">
       <span class="icon">🏆</span>

--- a/style.css
+++ b/style.css
@@ -141,7 +141,7 @@ h1 { color: #5d1917; text-shadow: 1px 1px 2px #ccc; }
   position: fixed;
   font-size: 30px;
   pointer-events: none;
-  z-index: 100;
+  z-index: 450;
   transition: all 0.6s ease-out;
   opacity: 0;
 }
@@ -229,45 +229,103 @@ h1 { color: #5d1917; text-shadow: 1px 1px 2px #ccc; }
   left: -22vw;
   width: min(24vw, 280px);
   height: min(36vw, 360px);
+  pointer-events: none;
+  z-index: 60;
+  perspective: 1200px;
+  transform-origin: center bottom;
+  animation: strelets-wander 32s linear infinite;
+  will-change: transform;
+}
+
+.background-character__sprite {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  transform-origin: center bottom;
+  transform-style: preserve-3d;
+  animation: strelets-turn 32s linear infinite;
+}
+
+.background-character__image {
+  width: 100%;
+  height: 100%;
   background-image: url('strelets.png');
   background-repeat: no-repeat;
   background-size: contain;
   background-position: center bottom;
-  z-index: 60;
-  pointer-events: none;
-  opacity: 0;
-  animation: strelets-wander 26s linear infinite;
-  will-change: transform, opacity;
+  animation: strelets-bob 2.4s ease-in-out infinite;
+  will-change: transform;
 }
 
 @keyframes strelets-wander {
-  0% {
+  0%,
+  4% {
     transform: translate3d(0, -18px, 0) scale(0.86);
-    opacity: 0;
   }
-  5% {
-    transform: translate3d(8vw, 8px, 0) scale(0.9);
-    opacity: 1;
+  18% {
+    transform: translate3d(18vw, 4px, 0) scale(0.92);
   }
-  20% {
-    transform: translate3d(28vw, -10px, 0) scale(0.98);
+  32% {
+    transform: translate3d(42vw, 12px, 0) scale(1.02);
   }
-  40% {
-    transform: translate3d(50vw, 14px, 0) scale(1.06);
+  44% {
+    transform: translate3d(68vw, 18px, 0) scale(1.12);
   }
-  60% {
-    transform: translate3d(72vw, -8px, 0) scale(1.14);
+  49%,
+  51% {
+    transform: translate3d(118vw, 22px, 0) scale(1.26);
+  }
+  64% {
+    transform: translate3d(76vw, 16px, 0) scale(1.14);
   }
   80% {
-    transform: translate3d(96vw, 18px, 0) scale(1.22);
-    opacity: 1;
+    transform: translate3d(38vw, -2px, 0) scale(0.98);
   }
-  90% {
-    transform: translate3d(114vw, -14px, 0) scale(1.26);
-    opacity: 0.6;
+  92% {
+    transform: translate3d(12vw, -12px, 0) scale(0.9);
+  }
+  96%,
+  100% {
+    transform: translate3d(0, -18px, 0) scale(0.86);
+  }
+}
+
+@keyframes strelets-turn {
+  0%,
+  45% {
+    transform: rotateY(0deg);
+  }
+  49% {
+    transform: rotateY(0deg);
+  }
+  53% {
+    transform: rotateY(180deg);
+  }
+  57%,
+  95% {
+    transform: rotateY(180deg);
+  }
+  98% {
+    transform: rotateY(360deg);
   }
   100% {
-    transform: translate3d(130vw, 0, 0) scale(1.18);
-    opacity: 0;
+    transform: rotateY(360deg);
+  }
+}
+
+@keyframes strelets-bob {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  25% {
+    transform: translateY(-3%);
+  }
+  50% {
+    transform: translateY(-1%);
+  }
+  75% {
+    transform: translateY(-4%);
   }
 }


### PR DESCRIPTION
## Summary
- swap the background character back to strelets.png while keeping the layered structure
- retime the wander path so the walker pauses at each edge before heading the opposite way
- restrict the turn animation to the edge pauses so the sprite only flips when reversing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1701a721c83319bc09a9ac23af137