### PR TITLE
Tighten background character wander range

### DIFF
--- a/style.css
+++ b/style.css
@@ -82,7 +82,7 @@ index 6cee62cfe73de34ddd04d4bed46e3b2e6e7defff..f9d5d2059bf568d74a05ee46a85c99ae
  .background-character {
    position: fixed;
    bottom: 10vh;
-   left: -22vw;
+   left: -6vw;
    width: min(24vw, 280px);
    height: min(36vw, 360px);
 +  pointer-events: none;
@@ -124,7 +124,7 @@ index 6cee62cfe73de34ddd04d4bed46e3b2e6e7defff..f9d5d2059bf568d74a05ee46a85c99ae
 -  0% {
 +  0%,
 +  4% {
-     transform: translate3d(0, -18px, 0) scale(0.86);
+    transform: translate3d(6vw, -18px, 0) scale(0.86);
 -    opacity: 0;
    }
 -  5% {
@@ -136,38 +136,38 @@ index 6cee62cfe73de34ddd04d4bed46e3b2e6e7defff..f9d5d2059bf568d74a05ee46a85c99ae
 -  20% {
 -    transform: translate3d(28vw, -10px, 0) scale(0.98);
 +  32% {
-+    transform: translate3d(42vw, 12px, 0) scale(1.02);
++    transform: translate3d(32vw, 12px, 0) scale(1.02);
    }
 -  40% {
 -    transform: translate3d(50vw, 14px, 0) scale(1.06);
 +  44% {
-+    transform: translate3d(68vw, 18px, 0) scale(1.12);
++    transform: translate3d(52vw, 18px, 0) scale(1.12);
    }
 -  60% {
 -    transform: translate3d(72vw, -8px, 0) scale(1.14);
 +  49%,
 +  51% {
-+    transform: translate3d(118vw, 22px, 0) scale(1.26);
++    transform: translate3d(80vw, 22px, 0) scale(1.26);
 +  }
 +  64% {
-+    transform: translate3d(76vw, 16px, 0) scale(1.14);
++    transform: translate3d(54vw, 16px, 0) scale(1.14);
    }
    80% {
 -    transform: translate3d(96vw, 18px, 0) scale(1.22);
 -    opacity: 1;
-+    transform: translate3d(38vw, -2px, 0) scale(0.98);
++    transform: translate3d(30vw, -2px, 0) scale(0.98);
    }
 -  90% {
 -    transform: translate3d(114vw, -14px, 0) scale(1.26);
 -    opacity: 0.6;
 +  92% {
-+    transform: translate3d(12vw, -12px, 0) scale(0.9);
++    transform: translate3d(14vw, -12px, 0) scale(0.9);
    }
 +  96%,
    100% {
 -    transform: translate3d(130vw, 0, 0) scale(1.18);
 -    opacity: 0;
-+    transform: translate3d(0, -18px, 0) scale(0.86);
++    transform: translate3d(6vw, -18px, 0) scale(0.86);
 +  }
 +}
 +


### PR DESCRIPTION
## Summary
- reduce the base left offset for the background character and update wander keyframes so horizontal travel keeps the sprite on screen

## Testing
- python -m http.server 8000
- python - <<'PY'
viewport = 1280
base_left_vw = -6
base_width = min(0.24 * viewport, 280)

positions = {
    'left_pause': {'tx_vw': 6, 'scale': 0.86},
    'right_pause': {'tx_vw': 80, 'scale': 1.26}
}

for label, data in positions.items():
    tx_px = data['tx_vw'] / 100 * viewport
    base_px = base_left_vw / 100 * viewport
    scale = data['scale']
    scaled_width = base_width * scale
    offset_correction = (scale - 1) * base_width / 2
    left_edge = base_px + tx_px - offset_correction
    right_edge = left_edge + scaled_width
    print(label)
    print(f"  left_px={left_edge:.2f}")
    print(f"  right_px={right_edge:.2f}")
    print(f"  within_viewport={0 <= left_edge and right_edge <= viewport}")
PY

------
https://chatgpt.com/codex/tasks/task_e_68d17c68ec5c8331bd994af3710ca7a4